### PR TITLE
restructures exports

### DIFF
--- a/impl.js
+++ b/impl.js
@@ -1,0 +1,92 @@
+const cheerio = require('cheerio');
+const acorn = require('acorn');
+const acornWalk = require('acorn-walk');
+const fetch = require('node-fetch');
+
+const embedUrl = 'https://docs.google.com/presentation/d/{id}/embed';
+
+function getSlideIds(deckId) {
+  const url = embedUrl.replace('{id}', deckId);
+
+  return fetch(url)
+    .then((response) => response.text())
+    .then((body) => {
+      const $ = cheerio.load(body);
+      const slideIds = [];
+      $('script').each((i, elem) => {
+        if (!elem
+          || !elem.children
+          || elem.children.length < 1
+          || !elem.children[0].data) {
+          // || elem.children[0].data.indexOf('docData') === -1) {
+          return;
+        }
+        acornWalk.simple(acorn.parse(elem.children[0].data, { ecmaVersion: 2020 }),
+          {
+            VariableDeclaration: (node) => {
+              /* Find variable declarations that assign to a variable called
+              * "viewerData", and from it, extract the slide IDs.
+              */
+              node.declarations
+                .filter((decl) => decl.id.name === 'viewerData')
+                .forEach((decl) => {
+                  decl.init.properties
+                    .filter((prop) => prop.key.name === 'docData')
+                    .forEach((prop) => {
+                      prop.value.elements[1].elements
+                        .forEach((slideData) => {
+                          slideIds.push(slideData.elements[0].value);
+                        });
+                    });
+                });
+            },
+          });
+      });
+      return slideIds;
+    })
+    .catch((err) => {
+      console.error(err.stack || err.trace || err);
+      return Promise.reject(err);
+    });
+}
+
+/**
+ * returns a function that returns a single element from an array. the strategy
+ * for choosing that function may be the string 'random' or an integer indicating
+ * the array position to choose. If the strategy is unexpected or negative it
+ * will try to pull the first item. If the array is too small the func will
+ * return undefined.
+ *
+ * @param {String|Integer} strategy either 'random' or a positive integer
+ * @returns {Function(String):String} return a function that selects a single
+ * element from an array-like object
+ */
+function slideChooser(strategy) {
+  if (strategy === 'random') {
+    return (arr) => arr[Math.floor(Math.random() * arr.length)];
+  }
+  let index = Number.parseInt(strategy);
+  if (Number.isNaN(index) || index < 0) {
+    index = 0;
+  }
+  return (arr) => arr[index];
+}
+
+/**
+ * This provides a way build the context necessary to get a slide URL. We need
+ * both the deck, which is known early, and the slide id, which is determined in
+ * the process chain.
+ *
+ * @param {String} deckID the ID of the google presentation deck
+ * @returns {Function(String):String} return a function that takes the slideID
+ * and returns the full URL for that deck and slide combination
+ */
+function buildSlideURL(deckID) {
+  return (slideID) => `${embedUrl.replace('{id}', deckID)}#slide=id.${slideID}`;
+}
+
+module.exports = {
+  buildSlideURL,
+  getSlideIds,
+  slideChooser,
+};

--- a/index.js
+++ b/index.js
@@ -8,113 +8,23 @@
  *    mythmon
  */
 
-const cheerio = require('cheerio');
-const acorn = require('acorn');
-const acornWalk = require('acorn-walk');
-const fetch = require('node-fetch');
+const { buildSlideURL, getSlideIds, slideChooser } = require('./impl.js');
 
-const embedUrl = 'https://docs.google.com/presentation/d/{id}/embed';
+module.exports = (corsica) => {
+  corsica.on('gslide', (content) => {
+    const deck = content.id;
+    const slideNum = content.slide || 'random';
 
-function getSlideIds(deckId) {
-  const url = embedUrl.replace('{id}', deckId);
-
-  return fetch(url)
-    .then((response) => response.text())
-    .then((body) => {
-      const $ = cheerio.load(body);
-      const slideIds = [];
-      $('script').each((i, elem) => {
-        if (!elem
-          || !elem.children
-          || elem.children.length < 1
-          || !elem.children[0].data) {
-          // || elem.children[0].data.indexOf('docData') === -1) {
-          return;
-        }
-        acornWalk.simple(acorn.parse(elem.children[0].data, { ecmaVersion: 2020 }),
-          {
-            VariableDeclaration: (node) => {
-              /* Find variable declarations that assign to a variable called
-              * "viewerData", and from it, extract the slide IDs.
-              */
-              node.declarations
-                .filter((decl) => decl.id.name === 'viewerData')
-                .forEach((decl) => {
-                  decl.init.properties
-                    .filter((prop) => prop.key.name === 'docData')
-                    .forEach((prop) => {
-                      prop.value.elements[1].elements
-                        .forEach((slideData) => {
-                          slideIds.push(slideData.elements[0].value);
-                        });
-                    });
-                });
-            },
-          });
-      });
-      return slideIds;
-    })
-    .catch((err) => {
-      console.error(err.stack || err.trace || err);
-      return Promise.reject(err);
-    });
-}
-
-/**
- * returns a function that returns a single element from an array. the strategy
- * for choosing that function may be the string 'random' or an integer indicating
- * the array position to choose. If the strategy is unexpected or negative it
- * will try to pull the first item. If the array is too small the func will
- * return undefined.
- *
- * @param {String|Integer} strategy either 'random' or a positive integer
- * @returns {Function(String):String} return a function that selects a single
- * element from an array-like object
- */
-function slideChooser(strategy) {
-  if (strategy === 'random') {
-    return (arr) => arr[Math.floor(Math.random() * arr.length)];
-  }
-  let index = Number.parseInt(strategy);
-  if (Number.isNaN(index) || index < 0) {
-    index = 0;
-  }
-  return (arr) => arr[index];
-}
-
-/**
- * This provides a way build the context necessary to get a slide URL. We need
- * both the deck, which is known early, and the slide id, which is determined in
- * the process chain.
- *
- * @param {String} deckID the ID of the google presentation deck
- * @returns {Function(String):String} return a function that takes the slideID
- * and returns the full URL for that deck and slide combination
- */
-function buildSlideURL(deckID) {
-  return (slideID) => `${embedUrl.replace('{id}', deckID)}#slide=id.${slideID}`;
-}
-
-module.exports = {
-  buildSlideURL,
-  getSlideIds,
-  slideChooser,
-  default: (corsica) => {
-    corsica.on('gslide', (content) => {
-      const deck = content.id;
-      const slideNum = content.slide || 'random';
-
-      getSlideIds(deck)
-        .then(slideChooser(slideNum))
-        .then(buildSlideURL)
-        .then((slideUrl) => {
-          corsica.sendMessage('content', {
-            screen: content.screen,
-            type: 'url',
-            url: slideUrl,
-          });
+    getSlideIds(deck)
+      .then(slideChooser(slideNum))
+      .then(buildSlideURL)
+      .then((slideUrl) => {
+        corsica.sendMessage('content', {
+          screen: content.screen,
+          type: 'url',
+          url: slideUrl,
         });
-      return Promise.resolve(content);
-    });
-  },
+      });
+    return Promise.resolve(content);
+  });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsica-google-presentation",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Show Google presentations on Corsica",
   "main": "index.js",
   "scripts": {

--- a/tests.js
+++ b/tests.js
@@ -3,10 +3,17 @@
 const assert = require('assert');
 const { describe, it } = require('mocha');
 
-const { slideChooser, buildSlideURL, getSlideIds } = require('.');
+const { slideChooser, buildSlideURL, getSlideIds } = require('./impl');
+const corsicaGooglePresentation = require('.');
 
 const corsicaDemoPresentationDeckID = '1_RWJt6XslTBeB04XjYJk71mM7DR49YKDVmZc5ZlWwUo';
 const corsicaDemoSlideIDs = ['g7e85c7fed4_1_36', 'g715e31125c_0_0', 'g7134ada0df_0_0'];
+
+describe('corsica expects things about this module', () => {
+  it('should export as a function', () => {
+    assert.strictEqual(typeof corsicaGooglePresentation, 'function');
+  });
+});
 
 describe('the non-corsica business logic', () => {
   it('should choose a valid random index', () => {


### PR DESCRIPTION
Corsica expects the imported library to present a function, and node's require is dumb as you can imagine. The 0.5.0 version returns an object that needs to be destructured. This shift was made to enable testing of the component functions.  Corsica doesn't rely on es6 modules, though, so simply naming one of those functions to be the `default` isn't sufficient. Instead this patch moves most of the business logic over to an impl function that can be tests, and then imports and re-exports those through a facade that matches Corsica's expectation