### PR TITLE
properly initialize the slide URL builder

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = (corsica) => {
 
     getSlideIds(deck)
       .then(slideChooser(slideNum))
-      .then(buildSlideURL)
+      .then(buildSlideURL(deck))
       .then((slideUrl) => {
         corsica.sendMessage('content', {
           screen: content.screen,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corsica-google-presentation",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "Show Google presentations on Corsica",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
the buildSlideUrl function was missing the deck ID, and so the url being sent to corsica was not a url at all but a function that would produce a bad url.

This error lies outside of the test suite and was verified fixed in a local copy of moz-corsica.

This patch bumps the version to 1.0 to indicate that this API should be considered stable, if only because I intend to wash my hands of it as soon as this ships.

fixes #3